### PR TITLE
[JS typewriter] Handle backspace at the beginning of a line

### DIFF
--- a/src/tbt-typewriter.js
+++ b/src/tbt-typewriter.js
@@ -101,9 +101,16 @@ function TBT() {
 	    if(cur_x > 0) {
 		cur_x--;
 		col--;
-	    } else { // backspace at the beginning of a line
-		     // move everything up one line
-		// TODO
+	    } else {
+	    	 // backspace at the beginning of a line
+	    	 cur_y--; row--;
+	    	 cur_x = col = text[row].length;
+	     	 // move everything up one line
+	     	 var max = text.length;
+	     	 for (var r = row+1; r < max; r++) {
+	     	 	text[r] = text[r+1];
+	     	 }
+	     	 text[max-1] = [];
 	    }
 	    break;
 


### PR DESCRIPTION
It makes the backspace key work as expected when you press it at the beginning of a line.
